### PR TITLE
fixed inconsistent word count issue (Github issue #7)

### DIFF
--- a/lib/middleman-spellcheck/spellchecker.rb
+++ b/lib/middleman-spellcheck/spellchecker.rb
@@ -21,11 +21,16 @@ class Spellchecker
   end
 
   def self.check(text, lang='en')
-    words   = text.split(/[^A-Za-z’']+/)
-    results = query(words.join(" "), lang).map do |query_result|
+    # join then re-split the word list to get a consistent word count,
+    # because sometimes there's a "" (blank) word in the array that gets lost,
+    # which makes the maps not equal, leading to an off by one type issue, where
+    # the reported mispelled word is actually a correct word.
+    # see: https://github.com/minivan/middleman-spellcheck/issues/7
+    words   = text.split(/[^A-Za-z’']+/).join(" ")
+    results = query(words, lang).map do |query_result|
       correct?(query_result)
     end
 
-    words.zip(results).map {|word, correctness| { word: word, correct: correctness } }
+    words.split(" ").zip(results).map {|word, correctness| { word: word, correct: correctness } }
   end
 end


### PR DESCRIPTION
I had the same problems as issue #7, with correctly spelled words being reported misspelled.

 I found that sometimes Nokogiri's doc.text included some blank words in the array (ex: ["", "Title", "Text"]). When the text was joined to be parsed by aspell, it would ignore the blank words, leading to an inconsistent array size when sending the new_result to be mapped onto the original word list. So, now the code joins the word list right away, then re-splits it before zipping it up with the results, which ensures that both the results array and the new word list array are the same size.

Hopefully that explains everything. If you know a better or faster way to ensure the consistency, feel free to modify my suggestions.
