### PR TITLE
Big update: middleman command; bugfixes; language parameter, unicode

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ Add the following to middleman's `config.rb`:
 
     activate :spellcheck
 
+Spellcheck is run automatically after build, but you can also check individual files and subdirectories:
+
+```
+middleman spellcheck source/about.html
+middleman spellcheck source/blog/
+```
+
 ## Usage
 
 You can spellcheck only some resources using a regex with the URL:
@@ -51,12 +58,20 @@ example, to use Polish dictionary, use:
 activate :spellcheck, lang: "pl"
 ```
 
+If you define the ``lang`` metadata in your pages / articles, then spellcheck will use those language.
+
 Middleman-spellcheck can issue many warnings if you run it over a new
 content. If you want to give yourself a chance to fix mistakes gradually and
 not fail each time you build, use :dontfail flag:
 
 ```ruby
-activate :spellcheck, lang: en, dontfail: 1
+activate :spellcheck, lang: "en", dontfail: 1
+```
+
+You can also disable the automatic spellcheck after build (and only run manual checks from the command line):
+
+```ruby
+activate :spellcheck, run_after_build: false
 ```
 
 Advanced users wishing to invoke Middleman-spellcheck backend (Aspell) with

--- a/lib/middleman-spellcheck.rb
+++ b/lib/middleman-spellcheck.rb
@@ -1,7 +1,8 @@
 require "middleman-core"
 require "middleman-spellcheck/version"
+require "middleman-spellcheck/cli"
 
 ::Middleman::Extensions.register(:spellcheck) do
-    require "middleman-spellcheck/extension"
-      ::Middleman::Spellcheck::SpellcheckExtension
+  require "middleman-spellcheck/extension"
+  ::Middleman::Spellcheck::SpellcheckExtension
 end

--- a/lib/middleman-spellcheck/cli.rb
+++ b/lib/middleman-spellcheck/cli.rb
@@ -1,0 +1,29 @@
+module Middleman
+  module Cli
+    # This class provides an "spellchecl" command for the middleman CLI.
+    class Spellcheck < Thor
+      include Thor::Actions
+      namespace :spellcheck
+      desc "spellcheck FILE", "Run spellcheck on given file or path"
+      def spellcheck(path)
+        app = ::Middleman::Application.server.inst
+
+        articles = app.blog.articles.select{|article|
+          article.source_file.sub(Dir.pwd,'').sub(%r{^/},'')[/^#{Regexp.escape(path)}/]
+        }
+        if articles.empty?
+          $stderr.puts "File / Directory #{path} not exist"
+          exit 1
+        end
+        ext = app.extensions[:spellcheck]
+        articles.each do |resource|
+          say_status :spellcheck, "Running spell checker for #{resource.url}", :blue
+          current_misspelled = ext.spellcheck_resource(resource)
+          current_misspelled.each do |misspell|
+            say_status :misspell, ext.error_message(misspell), :red
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/middleman-spellcheck/cli.rb
+++ b/lib/middleman-spellcheck/cli.rb
@@ -6,7 +6,6 @@ module Middleman
       namespace :spellcheck
       desc "spellcheck FILE", "Run spellcheck on given file or path"
       def spellcheck(*paths)
-        binding.pry
         app = ::Middleman::Application.server.inst
 
         resources = app.sitemap.resources.select{|resource|

--- a/lib/middleman-spellcheck/cli.rb
+++ b/lib/middleman-spellcheck/cli.rb
@@ -5,18 +5,21 @@ module Middleman
       include Thor::Actions
       namespace :spellcheck
       desc "spellcheck FILE", "Run spellcheck on given file or path"
-      def spellcheck(path)
+      def spellcheck(*paths)
+        binding.pry
         app = ::Middleman::Application.server.inst
 
-        articles = app.blog.articles.select{|article|
-          article.source_file.sub(Dir.pwd,'').sub(%r{^/},'')[/^#{Regexp.escape(path)}/]
+        resources = app.sitemap.resources.select{|resource|
+          paths.any? {|path|
+            resource.source_file.sub(Dir.pwd,'').sub(%r{^/},'')[/^#{Regexp.escape(path)}/]
+          }
         }
-        if articles.empty?
+        if resources.empty?
           $stderr.puts "File / Directory #{path} not exist"
           exit 1
         end
         ext = app.extensions[:spellcheck]
-        articles.each do |resource|
+        resources.each do |resource|
           say_status :spellcheck, "Running spell checker for #{resource.url}", :blue
           current_misspelled = ext.spellcheck_resource(resource)
           current_misspelled.each do |misspell|

--- a/lib/middleman-spellcheck/extension.rb
+++ b/lib/middleman-spellcheck/extension.rb
@@ -14,8 +14,10 @@ module Middleman
       option :cmdargs, "", "Pass alternative command line arguments"
       option :debug, 0, "Enable debugging (for developers only)"
       option :dontfail, 0, "Don't fail when misspelled words are found"
+      option :run_after_build, true, "Run Spellcheck after build"
 
       def after_build(builder)
+        return if !options.run_after_build
         Spellchecker.cmdargs=(options.cmdargs)
         Spellchecker.debug_enabled=(options.debug)
         filtered = filter_resources(app, options.page)

--- a/lib/middleman-spellcheck/spellchecker.rb
+++ b/lib/middleman-spellcheck/spellchecker.rb
@@ -47,9 +47,6 @@ class Spellchecker
       val = f.gets.strip()	# skip the Aspell's intro
       sdbg "Expected Aspell intro, got #{val}"
       words.each do |word|
-        if word[0] == "'"
-          word = word[1..-1]
-        end
         sdbg "-> Writing word '#{word}'"
         f.write(word + "\n")
         f.flush

--- a/lib/middleman-spellcheck/spellchecker.rb
+++ b/lib/middleman-spellcheck/spellchecker.rb
@@ -78,7 +78,7 @@ class Spellchecker
     text.gsub! '’', '\''
     sdbg "self.check got raw text:\n#{text}\n"
 
-    words = text.split(/[^A-Za-z']+/).select { |s|
+    words = text.split(/[^\p{L}']+/).select { |s|
       s != "" and s != "'s" and s != "'"
     }.uniq
     sdbg "self.check word array:\n#{words}\n"

--- a/lib/middleman-spellcheck/spellchecker.rb
+++ b/lib/middleman-spellcheck/spellchecker.rb
@@ -47,6 +47,9 @@ class Spellchecker
       val = f.gets.strip()	# skip the Aspell's intro
       sdbg "Expected Aspell intro, got #{val}"
       words.each do |word|
+        if word[0] == "'"
+          word = word[1..-1]
+        end
         sdbg "-> Writing word '#{word}'"
         f.write(word + "\n")
         f.flush
@@ -57,7 +60,7 @@ class Spellchecker
 
         # skip the empty line
         val = f.gets()
-	sdbg "Expected empty line, got '#{val}'"
+        sdbg "Expected empty line, got '#{val}'"
 
         result << word_check_res
       end
@@ -76,8 +79,8 @@ class Spellchecker
     sdbg "self.check got raw text:\n#{text}\n"
 
     words = text.split(/[^A-Za-z']+/).select { |s|
-       s != "" and s != "'s" and s != "'"
-    }
+      s != "" and s != "'s" and s != "'"
+    }.uniq
     sdbg "self.check word array:\n#{words}\n"
 
     results = query(words, lang).map do |query_result|

--- a/lib/middleman-spellcheck/spellchecker.rb
+++ b/lib/middleman-spellcheck/spellchecker.rb
@@ -57,10 +57,11 @@ class Spellchecker
         # should be * or &
         word_check_res = f.gets.strip()
         sdbg "<- got result '#{word_check_res}'"
-
-        # skip the empty line
-        val = f.gets()
-        sdbg "Expected empty line, got '#{val}'"
+        if word_check_res != ""
+          # skip the empty line
+          val = f.gets()
+          sdbg "Expected empty line, got '#{val}'"
+        end
 
         result << word_check_res
       end

--- a/lib/middleman_extension.rb
+++ b/lib/middleman_extension.rb
@@ -1,1 +1,2 @@
 require "middleman-spellcheck"
+require 'middleman-core/cli'

--- a/spec/lib/middleman-spellcheck/spellcheck_spec.rb
+++ b/spec/lib/middleman-spellcheck/spellcheck_spec.rb
@@ -68,4 +68,14 @@ describe Spellchecker do
                         { word: "user", correct: true }]
     end
   end
+
+  context "Unicode" do
+    let(:text) { "café hånk 你好" }
+
+    it "splits correctly on unicode chars, doesnt crash on Chinese chars" do
+      result.should == [{ word: "café", correct: false },
+                        { word: "hånk", correct: false },
+                        { word: "你好", correct: false }]
+    end
+  end
 end

--- a/spec/lib/middleman-spellcheck/spellcheck_spec.rb
+++ b/spec/lib/middleman-spellcheck/spellcheck_spec.rb
@@ -3,7 +3,7 @@ require_relative '../../../lib/middleman-spellcheck/spellchecker'
 
 describe Spellchecker do
   let(:text)   { "hello, world! of txet" }
-  let(:result) { Spellchecker.check(text) }
+  let(:result) { Spellchecker.check(text, "en") }
 
   context "with one wrong word" do
     it "can spell check words" do
@@ -55,8 +55,17 @@ describe Spellchecker do
 
     it "whitelists the word" do
       result.should == [{ word: "A", correct: true },
-                        { word: "user’s", correct: true },
+                        { word: "user's", correct: true },
                         { word: "page", correct: true }]
+    end
+  end
+
+  context "Bugs" do
+    let(:text) { "'http user" }
+
+    it "don't crash" do
+      result.should == [{ word: "'http", correct: false },
+                        { word: "user", correct: true }]
     end
   end
 end


### PR DESCRIPTION
Hello, 

I've done:

* fixed the failing specs
* fixed bugs, when a word is not a word that aspell recognizes, e.g. 'foo  or 你好 immediately returns empty string by Aspell -> spellcheck would choke on those words and hang forever in ``f.gets``
* Added command line command: ``middleman spellcheck source/blog/ source/about.erb`` to manually run this command for individual files
* non-English languages work now to, as i replaced the letter regex with ``\p{L}``, so all unicode letters are selected
* removed script, style and code blocks from spellcheck, as those are likely not intended to be fixed
* Added config option to disable the automatic run after build (default behavior as before = always run)
* if lang is defined on individual resources, that lang will be used for spellcheck, too. Also, I added a clause, to make the lang option callable, so this lang can be determined for a post: ``active :spellcheck, lang: ->(r) { r.lang.to_s }``

Let me know what you think! I can try to split thinks up, but that is a little work, as some changes relate to each other