### PR TITLE
Spellcheck-allowed from each article's frontmatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,3 +88,8 @@ activate :spellcheck, debug: 1
 ## Thanks
 
 Special thanks to [Readbeard-Tech](https://rubygems.org/profiles/redbeard-tech) for the [spellchecker](https://rubygems.org/gems/spellchecker) gem, which this code is based upon.
+
+# Author
+
+- Wojciech Adam Koszek, [wojciech@koszek.com](mailto:wojciech@koszek.com)
+- [http://www.koszek.com](http://www.koszek.com)

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ This will pull up simple CLI menu and for each misspelled word, you'll have
 a following choice
 
 | Key to press | Effect |
-+--------------+--------|
+|--------------|--------|
 | g | Add the word to the `spellcheck_allow_file` |
 | f | Add the word to this article's front-matter |
 | i | Ignore the word for now and deal with it later |

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ spellcheck-allowed:
 - Linux
 ```
 
+Look into section "Fixing spelling mistakes" to help yourself with fixing
+spelling problems in already existing articles.
+
 Middleman-spellcheck automatically ignores `.css`, `.js`, & `.coffee` file
 extensions. If there are some additional file type extensions that you would
 like to skip:
@@ -102,6 +105,54 @@ extensive amount of debugging.
 ```ruby
 activate :spellcheck, debug: 1
 ```
+
+## Fixing spelling mistakes
+
+The `middleman-spellchecker` extension is likely to generate large number
+of false-positives, e.g.: words which the spellchecker will consider
+incorrect (not present in a dictionary), which yet may have a valid meaning
+in the article's context. Common problems are acronyms, technical terms and
+names. To solve this, `middleman-spellcheck` offers two solutions:
+
+1. The `spellcheck_allow_file` file, which points to the path with a file
+containing words considered correct. Author of the website may decide which
+words are allowed to be used site-wide. Example: if you write a lot about
+IBM products, this file would have names such as "IBM", "AIX" or "DB/2".
+
+2. The `spellcheck-allow` keyword in a frontmatter, which will work in the
+context of this particular article, but not other articles. Example: your
+blog is about IBM, but 1 article is about AirBnB. You'd put `AirBnB` into
+your front-matter.
+
+To set the global file, use the following clause in your `config.rb`:
+
+	set :spellcheck_allow_file, "./data/words_allowed.txt"
+
+To use 2nd solution, add the following to your frontmatter:
+
+	spellcheck-allow:
+	- "AirBnB"
+
+The `middleman-spellcheck` also comes with a simple CLI for fixing many
+problems in your articles. To invoke:
+
+	middleman spellcheck source/blog/2015-11-01-nginx-on-travis-ci.md --fix
+
+This will pull up simple CLI menu and for each misspelled word, you'll have
+a following choice
+
+| Key to press | Effect |
++--------------+--------|
+| g | Add the word to the `spellcheck_allow_file` |
+| f | Add the word to this article's front-matter |
+| i | Ignore the word for now and deal with it later |
+
+
+After the run is finished, `middleman-spellchecker` will write a fixed file
+to `source/blog/2015-11-01-nginx-on-travis-ci.md.fixed`. This is a safe
+choice for not creating damage. If you don't want to fiddle with it, the
+`--inplace` switch will make changes dynamically, and the input file will
+get overwritten.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,17 @@ If there are some words that you would like to be allowed
 activate :spellcheck, allow: ["Gooby", "pls"]
 ```
 
+You can also add allowed words to the front-matter through the
+`spellcheck-allowed` keyword. Example:
+
+```
+title: "Some time ago"
+...
+spellcheck-allowed:
+- GitHub
+- Linux
+```
+
 Middleman-spellcheck automatically ignores `.css`, `.js`, & `.coffee` file
 extensions. If there are some additional file type extensions that you would
 like to skip:

--- a/README.md
+++ b/README.md
@@ -114,8 +114,3 @@ activate :spellcheck, debug: 1
 ## Thanks
 
 Special thanks to [Readbeard-Tech](https://rubygems.org/profiles/redbeard-tech) for the [spellchecker](https://rubygems.org/gems/spellchecker) gem, which this code is based upon.
-
-# Author
-
-- Wojciech Adam Koszek, [wojciech@koszek.com](mailto:wojciech@koszek.com)
-- [http://www.koszek.com](http://www.koszek.com)

--- a/lib/middleman-spellcheck/cli.rb
+++ b/lib/middleman-spellcheck/cli.rb
@@ -3,8 +3,67 @@ module Middleman
     # This class provides an "spellchecl" command for the middleman CLI.
     class Spellcheck < Thor
       include Thor::Actions
+
+      check_unknown_options!
+
+      namespace :spellcheck
+
+      no_commands {
+        def misspell_ask(misspell, allow_file)
+          if not options[:fix]
+            return false
+          end
+
+          print "-" * 70, "\n"
+          print "'#{misspell[:word]}' is misspelled. What to do?:\n"
+          print "g\tadd allowed word to '#{allow_file}'\n" if allow_file
+          print "f\tadd allowed word to frontmatter\n"
+          print "i\tignore word (deal with it later)\n"
+
+          print "Select option and press ENTER:\n"
+          STDIN.gets()[0]
+        end
+
+        def misspell_fixes_global(resource, words_allow_global, allow_file)
+          open(allow_file, 'a') { |f|
+            words_allow_global.each do |w|
+              f.puts "#{w}\t#\t#{resource.source_file}\n"
+            end
+          }
+        end
+
+        def misspell_fixes_frontmatter(resource, words_allow_frontmatter)
+          data = File.read(resource.source_file)
+          if options[:inplace] then fn_ext = "" else ".fixed" end
+          fn_fixed = "#{resource.source_file}#{fn_ext}"
+          fixed = File.open(fn_fixed, "w")
+          sep_tag_cnt = 0
+          data.each_line do |line|
+            if line =~ /^\-\-\-$/ then
+              sep_tag_cnt += 1
+            end
+
+            if sep_tag_cnt == 2 then
+              fixed.puts "spellcheck-allow:\n"
+              words_allow_frontmatter.each do |w|
+                fixed.puts "- \"#{w}\"\n"
+              end
+              fixed.puts "---\n"
+              sep_tag_cnt = nil
+            else
+              fixed.puts line
+            end
+          end
+          fixed.close()
+          print "Fixed spellchecked file written to #{fn_fixed}"
+        end
+      }
+
       namespace :spellcheck
       desc "spellcheck FILE", "Run spellcheck on given file or path"
+      method_option "fix", :type => :boolean, :aliases => "-f", :desc => "Fix spelling error interactively"
+      method_option "inplace", :type => :boolean, :aliases => "-i", :desc => "Modify files in place (dangerous)"
+
       def spellcheck(*paths)
         app = ::Middleman::Application.server.inst
 
@@ -14,18 +73,40 @@ module Middleman
           }
         }
         if resources.empty?
-          $stderr.puts "File / Directory #{path} not exist"
+          $stderr.puts "File / Directory #{paths} not exist"
           exit 1
         end
         ext = app.extensions[:spellcheck]
+
+        allow_file = app.config.defines_setting?(:spellcheck_allow_file) ?
+              app.config[:spellcheck_allow_file] : nil
+        if options[:fix] then
+          print "Spellchecker fix mode on! Will attempt to white-list some words\n"
+        end
         resources.each do |resource|
-          say_status :spellcheck, "Running spell checker for #{resource.url}", :blue
+          say_status :spellcheck, "Running spell checker for #{resource.source_file}", :blue
           current_misspelled = ext.spellcheck_resource(resource)
+
+          words_allow_frontmatter = []
+          words_allow_global = []
           current_misspelled.each do |misspell|
-            say_status :misspell, ext.error_message(misspell), :red
+            fix = misspell_ask(misspell, allow_file)
+            was_fixed = true
+            if    fix == 'g' then words_allow_global << misspell[:word]
+            elsif fix == 'f' then words_allow_frontmatter << misspell[:word]
+            else             was_fixed = false end
+
+            if was_fixed
+              say_status :spellcheck, "Fixed word #{misspell[:word]}"
+            else
+              say_status :misspell, ext.error_message(misspell), :red
+            end
           end
+          misspell_fixes_global(resource, words_allow_global, allow_file) unless words_allow_global.empty?
+          misspell_fixes_frontmatter(resource, words_allow_frontmatter) unless words_allow_frontmatter.empty?
         end
       end
+
     end
   end
 end

--- a/lib/middleman-spellcheck/cli.rb
+++ b/lib/middleman-spellcheck/cli.rb
@@ -55,7 +55,7 @@ module Middleman
             end
           end
           fixed.close()
-          print "Fixed spellchecked file written to #{fn_fixed}"
+          print "Fixed spellchecked file written to #{fn_fixed}\n"
         end
       }
 

--- a/lib/middleman-spellcheck/cli.rb
+++ b/lib/middleman-spellcheck/cli.rb
@@ -38,13 +38,19 @@ module Middleman
           fn_fixed = "#{resource.source_file}#{fn_ext}"
           fixed = File.open(fn_fixed, "w")
           sep_tag_cnt = 0
+          had_spellcheck_tag = false
           data.each_line do |line|
             if line =~ /^\-\-\-$/ then
               sep_tag_cnt += 1
             end
+            if line =~ /spellcheck-allow:/ then
+              had_spellcheck_tag = true
+            end
 
             if sep_tag_cnt == 2 then
-              fixed.puts "spellcheck-allow:\n"
+              if had_spellcheck_tag == false then
+                fixed.puts "spellcheck-allow:\n"
+              end
               words_allow_frontmatter.each do |w|
                 fixed.puts "- \"#{w}\"\n"
               end

--- a/lib/middleman-spellcheck/extension.rb
+++ b/lib/middleman-spellcheck/extension.rb
@@ -85,17 +85,27 @@ module Middleman
           else
             options.lang
           end
-        run_check(select_content(resource), lang)
+        run_check(resource, lang)
       end
 
-      def run_check(text, lang)
+      def run_check(resource, lang)
+        text = select_content(resource)
         results = Spellchecker.check(text, lang)
-        results = exclude_allowed(results)
+        results = exclude_allowed(resource, results)
         results.reject { |entry| entry[:correct] }
       end
 
-      def exclude_allowed(results)
-        results.reject { |entry| option_allowed.include? entry[:word].downcase }
+      def exclude_allowed(resource, results)
+        allowed_words = option_allowed
+        if resource.data.include?("spellcheck-allow") then
+          allowed_tmp = resource.data["spellcheck-allow"]
+          allowed_words += if allowed_tmp.is_a? Array
+                       allowed_tmp
+                     else
+                       [allowed_tmp]
+                     end
+        end
+        results.reject { |entry| allowed_words.include? entry[:word].downcase }
       end
 
       def option_allowed

--- a/lib/middleman-spellcheck/extension.rb
+++ b/lib/middleman-spellcheck/extension.rb
@@ -132,7 +132,6 @@ module Middleman
             next if line =~ /^#/ or line =~ /^$/
             ALLOWED_WORDS << line.partition('#').first.strip
           end
-          print "ALLOWED_WORDS: ", ALLOWED_WORDS, "\n"
         end
         ALLOWED_WORDS
       end

--- a/lib/middleman-spellcheck/extension.rb
+++ b/lib/middleman-spellcheck/extension.rb
@@ -96,25 +96,24 @@ module Middleman
       end
 
       def exclude_allowed(resource, results)
-        allowed_words = option_allowed
+        results.reject { |entry| allowed_words(resource).include? entry[:word].downcase }
+      end
+
+      def allowed_words(resource)
+        words_ok = if options.allow.is_a? Array
+                    options.allow
+                  else
+                    [options.allow]
+                  end
         if resource.data.include?("spellcheck-allow") then
           allowed_tmp = resource.data["spellcheck-allow"]
-          allowed_words += if allowed_tmp.is_a? Array
+          words_ok += if allowed_tmp.is_a? Array
                        allowed_tmp
                      else
                        [allowed_tmp]
                      end
         end
-        results.reject { |entry| allowed_words.include? entry[:word].downcase }
-      end
-
-      def option_allowed
-        allowed = if options.allow.is_a? Array
-                    options.allow
-                  else
-                    [options.allow]
-                  end
-        allowed.map(&:downcase)
+        words_ok.map(&:downcase)
       end
 
       def option_ignored_exts

--- a/lib/middleman-spellcheck/extension.rb
+++ b/lib/middleman-spellcheck/extension.rb
@@ -106,9 +106,9 @@ module Middleman
                   else
                     [options.allow]
                   end
-          words_ok += allowed_words_frontmatter(resource)
-          words_ok += allowed_words_file
-          words_ok.map(&:downcase)
+        words_ok += allowed_words_frontmatter(resource)
+        words_ok += allowed_words_file
+        words_ok.map(&:downcase)
       end
 
       def allowed_words_frontmatter(resource)

--- a/lib/middleman-spellcheck/extension.rb
+++ b/lib/middleman-spellcheck/extension.rb
@@ -34,7 +34,7 @@ module Middleman
 
         unless total_misspelled.empty?
           estr = "Build failed. There are spelling errors."
-          if options.dontfail
+          if options.dontfail != 0
             print "== :dontfail set! Will issue warning only, but not fail.\n"
             print estr, "\n"
           else

--- a/lib/middleman-spellcheck/extension.rb
+++ b/lib/middleman-spellcheck/extension.rb
@@ -10,7 +10,6 @@ module Middleman
       option :page, "/*", "Run only pages that match the regex through the spellchecker"
       option :tags, [], "Run spellcheck only on some tags from the output"
       option :allow, [], "Allow specific words to be misspelled"
-      option :allow_file, nil, "File with words allowed by the spellchecker"
       option :ignored_exts, [], "Ignore specific extensions (ex: '.xml')"
       option :lang, "en", "Language for spellchecking"
       option :cmdargs, "", "Pass alternative command line arguments"
@@ -126,8 +125,12 @@ module Middleman
       end
 
       def allowed_words_file
-        if ALLOWED_WORDS.empty? && options.allow_file != nil
-          lines = File.read(options.allow_file)
+        allow_file = nil
+        if app.config.defines_setting?(:spellcheck_allow_file)
+          allow_file = app.config[:spellcheck_allow_file]
+        end
+        if ALLOWED_WORDS.empty? && allow_file != nil
+          lines = File.read(allow_file)
           lines.split("\n").each do |line|
             next if line =~ /^#/ or line =~ /^$/
             ALLOWED_WORDS << line.partition('#').first.strip


### PR DESCRIPTION
Fixes issue #14 

I want to be able to white-list some words on the per-article basis. I use `spellcheck-allow` for this. Basically the user specifies the words she/he reviewed and knows they're fine.