### PR TITLE
Adds option to ignore specific directories when spellchecking

### DIFF
--- a/features/ignored_dirs.feature
+++ b/features/ignored_dirs.feature
@@ -1,0 +1,6 @@
+Feature: Building an application with the spell checker while ignoring specific directories
+
+  Scenario: The spelling errors in the parameters that are within ignored directories are skipped
+    Given a fixture app "ignored_dirs_app"
+    When I run `middleman build`
+    Then the exit status should be 0

--- a/fixtures/ignored_dirs_app/config.rb
+++ b/fixtures/ignored_dirs_app/config.rb
@@ -1,0 +1,1 @@
+activate :spellcheck, ignored_dirs: ["vendor"]

--- a/fixtures/ignored_dirs_app/source/check/index.html
+++ b/fixtures/ignored_dirs_app/source/check/index.html
@@ -1,0 +1,1 @@
+There are no spelling errors here

--- a/fixtures/ignored_dirs_app/source/vendor/index.html
+++ b/fixtures/ignored_dirs_app/source/vendor/index.html
@@ -1,0 +1,1 @@
+Theer are soome splelling erors her! Gooby pls.

--- a/lib/middleman-spellcheck/extension.rb
+++ b/lib/middleman-spellcheck/extension.rb
@@ -18,6 +18,7 @@ module Middleman
       option :debug, 0, "Enable debugging (for developers only)"
       option :dontfail, false, "Don't fail because misspelled words are found"
       option :run_after_build, true, "Run Spellcheck after build"
+      option :ignored_dirs, [], "Ignore specific directories"
 
       def after_build(builder)
         return if !options.run_after_build
@@ -90,6 +91,7 @@ module Middleman
       def filter_resources(app, pattern)
         app.sitemap.resources.select { |resource| resource.url.match(pattern) }
           .reject { |resource| option_ignored_exts.include? resource.ext }
+          .reject { |resource| option_ignored_dirs =~ resource.path }
       end
 
       def spellcheck_resource(resource)
@@ -162,6 +164,12 @@ module Middleman
                          [options.ignored_exts]
                        end
         REJECTED_EXTS + ignored_exts
+      end
+
+      def option_ignored_dirs
+        if options.ignored_dirs.any?
+          Regexp.new(options.ignored_dirs.join("|"))
+        end
       end
 
       def error_message(misspell)


### PR DESCRIPTION
The `page` option worked for me in most cases, but I found myself needing to be more specific about folders I wanted to ignore like vendor/bower_components/etc. This lets you specify an array of folder names to skip, relative to the `source` directory.
